### PR TITLE
Ftuoil Xelrash patch thwarg launcher name issue

### DIFF
--- a/Servers.xml
+++ b/Servers.xml
@@ -161,7 +161,7 @@
     <name>Levistras</name>
     <description>A 100% Botting-Free PvE Server! Apply through our Discord for access!</description>
     <emu>ACE</emu>
-    <server_host>Levistras.servequake.com</server_host>
+    <server_host>acportalstorm.com</server_host>
     <server_port>9000</server_port>
     <type>PvE</type>
     <status></status>

--- a/Servers.xml
+++ b/Servers.xml
@@ -278,7 +278,7 @@
   </ServerItem>
   <ServerItem>
     <id>9D17CE44-7DB5-40C1-B7BB-A01C9DE21D00</id>
-    <name>AChard</name>
+    <name>AChard</name> 
     <description>PvP ACE Retail Server including modifications from FX's twisted sick mind...</description>
     <emu>ACE</emu>
     <server_host>a-chard.ddns.net</server_host>

--- a/Servers.xml
+++ b/Servers.xml
@@ -13,6 +13,18 @@
     <discord_url>https://discord.gg/XV2wJtP</discord_url>
   </ServerItem>
   <ServerItem>
+    <id>03b2b89e-02e0-11eb-adc1-0242ac120002</id>
+    <name>Lostwoods Ac</name>
+    <description>Custom Progressive Content. 1x Rate 3x Drop rates</description>
+    <emu>ACE</emu>
+    <server_host>LostWoodsAc.hopto.org</server_host>
+    <server_port>9000</server_port>
+    <type>PVE</type>
+    <status>Stable</status>
+    <website_url></website_url>
+    <discord_url>https://discord.gg/DShQjRJ</discord_url>
+  </ServerItem>
+  <ServerItem>
     <id>a47807ba-9aae-4790-98ae-e9f9e9177318</id>
     <name>RisingSun</name>
     <description>A PVE server currently goal is to follow path toward end of game retail.</description>

--- a/Servers.xml
+++ b/Servers.xml
@@ -135,10 +135,10 @@
   <ServerItem>
     <id>26D70BC9-78E9-4DDC-BCFF-7D5B36F6AC17</id>
     <name>GDLE Test</name>
-    <description>Test server for Reefcull and Hightide servers.</description>
+    <description>Test server for Reefcull and Harvestbud servers.</description>
     <emu>GDL</emu>
-    <server_host>gdletest.connect-to-server.online</server_host>
-    <server_port>9000</server_port>
+    <server_host>test.gdleac.com</server_host>
+    <server_port>9050</server_port>
     <type></type>
     <status></status>
     <website_url></website_url>

--- a/Servers.xml
+++ b/Servers.xml
@@ -209,7 +209,7 @@
     <name>Winterthaw</name>
     <description>Casual server with convenience changes and plans for custom content.</description>
     <emu>ACE</emu>
-    <server_host>23.20.74.30</server_host>
+    <server_host>71.87.108.159</server_host>
     <server_port>9000</server_port>
     <type>PvE</type>
     <status></status>


### PR DESCRIPTION
Removed ' from server name. ThwargLauncher is not parsing the name correct and causing the client to close on users.