### PR TITLE
Fix Podtide expired Discord invite url

### DIFF
--- a/Servers.xml
+++ b/Servers.xml
@@ -250,6 +250,6 @@
     <type>PvP</type>
     <status>Stable</status>
     <website_url></website_url>
-    <discord_url>https://discord.gg/NeT2BDEYHZ</discord_url>
+    <discord_url>https://discord.gg/Exrhgj8dKV</discord_url>
   </ServerItem>
 </ArrayOfServerItem>


### PR DESCRIPTION
Current Discord invite link is expired for Podtide—updated to working link.