### PR TITLE
Update Servers.xml

### DIFF
--- a/Servers.xml
+++ b/Servers.xml
@@ -264,4 +264,16 @@
     <website_url>https://morntide.ac</website_url>
     <discord_url>https://discord.gg/7Gcc2XFqhJ</discord_url>
   </ServerItem>
+  <ServerItem>
+    <id>94bb861b-5ca2-4105-bc1b-d41519301780</id>
+    <name>Modclaim</name>
+    <description>A PVE AC Server evolving to provide a end of retail experience running ACEmulator with addition of "persistent arrows".</description>
+    <emu>ACE</emu>
+    <server_host>ngc1069.dynamic-dns.net</server_host>
+    <server_port>9000</server_port>
+    <type>PvE</type>
+    <status>Stable</status>
+    <website_url></website_url>
+    <discord_url></discord_url>
+  </ServerItem>
 </ArrayOfServerItem>


### PR DESCRIPTION
Added Modclaim, a server with persistent arrows... the arrows that don't hit a creature (the misses) stay stuck in the ground, and other environment surfaces.. you can collect and re-use them.   This was how it was in retail in the early days.. the feature was removed due to server lag... but with the small player base and powerful servers this should not be an issue today.