### PR TITLE
Change Funkytown 2.0's port from 9000 to 9050

### DIFF
--- a/Servers.xml
+++ b/Servers.xml
@@ -126,7 +126,7 @@
     <description>Retail with a little bit of Funky</description>
     <emu>GDL</emu>
     <server_host>funkytownac.com</server_host>
-    <server_port>9000</server_port>
+    <server_port>9050</server_port>
     <type>PvE</type>
     <status>Stable</status>
     <website_url>https://funkytownac.com</website_url>


### PR DESCRIPTION
I've tested that 9050 is right and that the server is still up. Also https://treestats.net/FunkyTown%202.0.