### PR TITLE
add FunkyTown PK discord, update domain

### DIFF
--- a/Servers.xml
+++ b/Servers.xml
@@ -137,11 +137,11 @@
     <name>FunkyTown 2.0</name>
     <description>Retail with a little bit of Funky</description>
     <emu>GDL</emu>
-    <server_host>ac.funkyac.ga</server_host>
+    <server_host>funkytownac.com</server_host>
     <server_port>9050</server_port>
     <type>PvE</type>
     <status>Stable</status>
-    <website_url>https://www.funkyac.ga</website_url>
+    <website_url>https://www.funkytownac.com/</website_url>
     <discord_url>https://discord.gg/HqHjHB3R97</discord_url>
   </ServerItem>
   <ServerItem>
@@ -149,23 +149,23 @@
     <name>FunkyTown PK</name>
     <description>Retail with a little bit of Funky. PVP ONLY. Not moderated, No Warranties, No Refunds.</description>
     <emu>GDL</emu>
-    <server_host>ac.funkyac.ga</server_host>
+    <server_host>funkytownac.com</server_host>
     <server_port>9059</server_port>
     <type>PvP</type>
     <status>Stable</status>
-    <website_url>https://www.funkyac.ga</website_url>
-    <discord_url>https://discord.gg/HqHjHB3R97</discord_url>
+    <website_url>https://www.funkytownac.com/</website_url>
+    <discord_url>https://discord.gg/CHgzDYVk</discord_url>
   </ServerItem>
   <ServerItem>
     <id>C6848B06-CA87-4CD1-B615-0C2A9781D01C</id>
     <name>FunkyTEST</name>
     <description>FunkyTown 2.0 Test Server</description>
     <emu>GDL</emu>
-    <server_host>ac.funkyac.ga</server_host>
+    <server_host>funkytownac.com</server_host>
     <server_port>9055</server_port>
     <type>PvE</type>
     <status>Experimental</status>
-    <website_url>https://www.funkyac.ga</website_url>
+    <website_url>https://www.funkytownac.com/</website_url>
     <discord_url>https://discord.gg/HqHjHB3R97</discord_url>
   </ServerItem>
   <ServerItem>

--- a/Servers.xml
+++ b/Servers.xml
@@ -142,7 +142,7 @@
     <type>PvE</type>
     <status>Stable</status>
     <website_url>https://www.funkytownac.com/</website_url>
-    <discord_url>https://discord.gg/HqHjHB3R97</discord_url>
+    <discord_url>https://discord.gg/4gzFWTMu</discord_url>
   </ServerItem>
   <ServerItem>
     <id>74C3F06D-1D0C-4BCA-83DE-2C8EE342DFD0</id>
@@ -166,7 +166,7 @@
     <type>PvE</type>
     <status>Experimental</status>
     <website_url>https://www.funkytownac.com/</website_url>
-    <discord_url>https://discord.gg/HqHjHB3R97</discord_url>
+    <discord_url>https://discord.gg/4gzFWTMu</discord_url>
   </ServerItem>
   <ServerItem>
     <id>bb791cc4-05c2-49ee-8473-9ab547cefce7</id>


### PR DESCRIPTION

Adding separate Discord for FunkyTown PK
Update FunkyTown 2.0 and FunkyTEST Discord invites, to invites created by the server owner
Update domain to funkytownac.com, and website to https://www.funkytownac.com for FunkyTown 2.0, FunkyTEST, FunkyTown PK
