### PR TITLE
Automate removing expired servers

### DIFF
--- a/.github/workflows/actions/expire-servers/Dockerfile
+++ b/.github/workflows/actions/expire-servers/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:3.2.0
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY main.rb ./
+
+ENTRYPOINT ["ruby", "/main.rb"]

--- a/.github/workflows/actions/expire-servers/Gemfile
+++ b/.github/workflows/actions/expire-servers/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'nokogiri', '1.14.0'

--- a/.github/workflows/actions/expire-servers/Gemfile.lock
+++ b/.github/workflows/actions/expire-servers/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.14.0-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.6.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  nokogiri (= 1.14.0)
+
+BUNDLED WITH
+   2.4.1

--- a/.github/workflows/actions/expire-servers/action.yml
+++ b/.github/workflows/actions/expire-servers/action.yml
@@ -1,0 +1,5 @@
+name: 'Expire servers'
+description: 'Produces a new Servers.xml with expired servers removed and opens a pull request'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/workflows/actions/expire-servers/main.rb
+++ b/.github/workflows/actions/expire-servers/main.rb
@@ -1,0 +1,47 @@
+require 'uri'
+require 'net/http'
+require 'nokogiri'
+require 'json'
+require 'date'
+
+WORKSPACE_DIR = '/github/workspace'
+MONTHS_UNTIL_EXPIRED = 3
+
+class FetchTreeStatsServers
+  def call
+    response = submit_request
+    parse(response)
+  end
+
+  private
+
+  def submit_request
+    Net::HTTP.get_response(URI('https://servers.treestats.net/api/servers/'))
+  end
+
+  def parse(response)
+    JSON
+      .parse(response.body)
+      .map do |server| 
+        { 
+          id: server['guid'],
+          last_seen: DateTime.parse(server.dig('status','last_seen')) 
+        }
+      end
+  end
+end
+
+servers = FetchTreeStatsServers.new.call
+
+expire_time = DateTime.now.prev_month(MONTHS_UNTIL_EXPIRED)
+expired_servers = servers.select { |s| s[:last_seen] <= expire_time}
+expired_server_ids = expired_servers.map { |s| s[:id] }
+
+contents = File.read("#{WORKSPACE_DIR}/Servers.xml")
+doc = Nokogiri::XML(contents)
+
+doc.css("ArrayOfServerItem ServerItem")
+  .select { |element| expired_server_ids.include?(element.at_css('id').content) }
+  .each(&:remove)
+
+File.write("#{WORKSPACE_DIR}/Servers.xml", doc.to_s)

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,25 @@
+name: Maintenance
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Expire servers
+      uses: ./.github/workflows/actions/expire-servers
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        branch: remove-expired-servers
+        delete-branch: true
+        title: 'Remove expired servers'


### PR DESCRIPTION
Requirements: 
- Permissions in the repo must be updated to allow actions to create pull requests. See the Create Pull Request action docs, [here](https://github.com/marketplace/actions/create-pull-request#workflow-permissions)

How it's triggered:
- Manually via GitHub's Actions tab
- Scheduled once a month

How it works:
- Collects last seen times for each server from `https://servers.treestats.net`. For more info on how this data source works, go [here](https://github.com/amoeba/ac-server-monitor#how-this-works)
- Determines which servers haven't successfully received a login packet in 3 months.
- If any expired servers are found, it modifies the `Servers.xml` and opens a pull request
- If a previous PR is still open, The action will modify and force push to the same branch/PR.

 