### PR TITLE
Create Action to check Servers.xml parses

### DIFF
--- a/.github/workflows/xmllint.yml
+++ b/.github/workflows/xmllint.yml
@@ -1,0 +1,14 @@
+name: xmllint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install xmllint
+        run: sudo apt-get -y install libxml2-utils
+      - name: Check that Servers.xml at least parses cleanly
+        run: |
+          xmllint Servers.xml


### PR DESCRIPTION
This helps avoid merging a PR with a typo that causes the document to fail to parse. Full schema validation could be added on top of this at a later point.

Putting up a PR for visibility mainly. I can merge later.