### PR TITLE
Fix comment bot failing when the check fails

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -26,7 +26,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⏳ Checking if I can connect and log in to ${{ steps.extract.outputs.ADDRESS }}. Give me a minute...'
+              body: "⏳ Checking if I can connect and log in to ${{ steps.extract.outputs.ADDRESS }}. Give me a minute..."
             })
       - name: Checkout ac-server-monitor
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '✅ ${{ steps.extract.outputs.ADDRESS }} was up and I was able to log in!'
+              body: "✅ ${{ steps.extract.outputs.ADDRESS }} was up and I was able to log in!"
             })
       - uses: actions/github-script@v6
         if: steps.check.outcome == 'failure'
@@ -60,5 +60,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🚫 ${{ steps.extract.outputs.ADDRESS }} was down or I couldn't log in.'
+              body: "🚫 ${{ steps.extract.outputs.ADDRESS }} was down or I couldn't log in."
             })


### PR DESCRIPTION
As seen in https://productionresultssa8.blob.core.windows.net/actions-results/79f2bf57-7512-4752-9ab0-71d7e59ea715/workflow-job-run-0644445a-5b57-5673-9dcf-fe651805afa5/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-08-23T00%3A28%3A34Z&sig=jJb8ifHNglBkF2Kxhf1XsQCsy73lCaWev0%2Bhh28nXM8%3D&ske=2025-08-23T10%3A21%3A07Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-08-22T22%3A21%3A07Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-08-23T00%3A18%3A29Z&sv=2025-05-05.